### PR TITLE
Add staticlib to crate-type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,21 +5,24 @@ authors = ["Jules de Smit <julesdesmit@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-canonical = { version = "0.5", optional = true }
-canonical_derive = {version = "0.5", optional = true}
-dusk-bls12_381 = { version = "0.6", default-features = false, features = ["groups"] }
-dusk-bytes = "0.1"
+canonical = { version = "0.6", optional = true }
+canonical_derive = {version = "0.6", optional = true}
+dusk-bls12_381 = { version = "0.8", default-features = false, features = ["groups"] }
+dusk-bytes = "0.1.4"
 rand = {version = "0.7", default-features = false}
-rand_core = {version = "0.5", default-features = false}
+rand_core = {version = "0.6", default-features = false}
 blake2 = {version = "0.9", default-features = false, optional = true}
 thiserror = {version = "1.0", default-features = false}
 libc = "0.2"
 
 [lib]
-crate-type = ["rlib"]
+crate-type = ["rlib", "staticlib"]
+
+[profile.dev]
+panic = "abort"
 
 [profile.release]
-panic = 'abort'
+panic = "abort"
 lto = true
 incremental = false
 codegen-units = 1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,3 +22,13 @@ pub use error::Error;
 pub use hash::{h0, h1};
 pub use keys::{apk::APK, public::PublicKey, secret::SecretKey};
 pub use signature::Signature;
+
+#[cfg(not(feature = "std"))]
+use core::panic::PanicInfo;
+
+/// This function is called on panic.
+#[cfg(not(feature = "std"))]
+#[panic_handler]
+fn panic(_info: &PanicInfo) -> ! {
+    loop {}
+}


### PR DESCRIPTION
This allows the crate to compile a .a file, so that
it can easily be used by the Go FFI package.

Fixes #12