### PR TITLE
Create capnproto implementation

### DIFF
--- a/src/keys/apk.rs
+++ b/src/keys/apk.rs
@@ -11,6 +11,7 @@ use crate::{Error, PublicKey};
 // use canonical::Canon;
 #[cfg(feature = "canon")]
 use canonical_derive::Canon;
+use dusk_bls12_381::G2Affine;
 #[cfg(feature = "std")]
 use dusk_bls12_381::G2Projective;
 
@@ -64,5 +65,14 @@ impl APK {
     /// Return the amount of bytes needed to serialize a [`APK`].
     pub const fn serialized_size() -> usize {
         96
+    }
+    pub fn to_raw_bytes(&self) -> [u8; G2Affine::RAW_SIZE] {
+        self.0.to_raw_bytes()
+    }
+
+    pub fn from_raw_bytes(
+        bytes: &[u8; G2Affine::RAW_SIZE],
+    ) -> Result<Self, Error> {
+        Ok(APK(PublicKey::from_raw_bytes(bytes)?))
     }
 }

--- a/src/keys/public.rs
+++ b/src/keys/public.rs
@@ -71,8 +71,12 @@ impl PublicKey {
         ))
     }
 
-    pub fn from_slice_unchecked(
-        bytes: &[u8; PublicKey::serialized_size()],
+    pub fn to_raw_bytes(&self) -> [u8; G2Affine::RAW_SIZE] {
+        self.0.to_raw_bytes()
+    }
+
+    pub fn from_raw_bytes(
+        bytes: &[u8; G2Affine::RAW_SIZE],
     ) -> Result<Self, Error> {
         unsafe { Ok(Self(G2Affine::from_slice_unchecked(bytes))) }
     }

--- a/src/svc/svc.rs
+++ b/src/svc/svc.rs
@@ -188,6 +188,7 @@ impl Signer for MySign {
     }
 }
 
+#[cfg(feature = "std")]
 impl MySign {
     fn slice_to_fixed<const N: usize>(s: &[u8]) -> Result<[u8; N], Status> {
         if s.len() != N {
@@ -278,7 +279,8 @@ impl MySign {
 #[cfg(feature = "std")]
 extern crate ctrlc;
 
-/// Default UDS path that Rusk GRPC-server will connect to.
+#[cfg(feature = "std")]
+/// Default UDS path that BLS12-381 GRPC-server will connect to.
 pub const SOCKET_PATH: &str = "/tmp/bls12381svc.sock";
 
 #[cfg(feature = "std")]
@@ -324,8 +326,10 @@ fn main() {
     panic!("std feature required");
 }
 
+#[cfg(feature = "std")]
 extern crate test;
 
+#[cfg(feature = "std")]
 #[cfg(test)]
 mod benches_svc {
     use dusk_bls12_381_sign::{PublicKey, SecretKey};
@@ -390,6 +394,7 @@ mod benches_svc {
     }
 }
 
+#[cfg(feature = "std")]
 #[cfg(test)]
 mod tests_svc {
     use crate::*;


### PR DESCRIPTION
Making a service with capnproto also requires using capnproto rpc. So far the service implementation is drafted and a client that tests that it's working is next. After that the #11 on bls12_381-sign-go will test and benchmark the service.

closes #20 