### PR TITLE
Speed up gRPC deserialisation

### DIFF
--- a/src/keys/apk.rs
+++ b/src/keys/apk.rs
@@ -11,6 +11,7 @@ use crate::{Error, PublicKey};
 // use canonical::Canon;
 #[cfg(feature = "canon")]
 use canonical_derive::Canon;
+use dusk_bls12_381::G2Affine;
 #[cfg(feature = "std")]
 use dusk_bls12_381::G2Projective;
 
@@ -64,5 +65,14 @@ impl APK {
     /// Return the amount of bytes needed to serialize a [`APK`].
     pub const fn serialized_size() -> usize {
         96
+    }
+    pub fn to_raw_bytes(&self) -> [u8; G2Affine::RAW_SIZE] {
+        self.0.to_raw_bytes()
+    }
+
+    pub fn from_raw_bytes(
+        bytes: &[u8; G2Affine::RAW_SIZE],
+    ) -> Result<Self, Error> {
+        Ok(APK(PublicKey::from_raw_bytes(bytes)?))
     }
 }

--- a/src/keys/public.rs
+++ b/src/keys/public.rs
@@ -71,6 +71,16 @@ impl PublicKey {
         ))
     }
 
+    pub fn to_raw_bytes(&self) -> [u8; G2Affine::RAW_SIZE] {
+        self.0.to_raw_bytes()
+    }
+
+    pub fn from_raw_bytes(
+        bytes: &[u8; G2Affine::RAW_SIZE],
+    ) -> Result<Self, Error> {
+        unsafe { Ok(Self(G2Affine::from_slice_unchecked(bytes))) }
+    }
+
     /// Return the amount of bytes needed to serialize a [`PublicKey`].
     pub const fn serialized_size() -> usize {
         96

--- a/src/svc/svc.rs
+++ b/src/svc/svc.rs
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
-
+#![feature(test)]
 #![cfg_attr(not(unix), allow(unused_imports))]
 
 #[cfg(feature = "std")]
@@ -77,6 +77,31 @@ macro_rules! slice_as {
 }
 
 #[cfg(feature = "std")]
+#[macro_export]
+macro_rules! slice_as_fixed {
+    ($slice:expr, $wrapper:ty, $note:literal, $length:expr) => {{
+        unsafe fn this_transmute(
+            xs: &[u8],
+        ) -> &[u8; <$length>] {
+            slice_as_array_transmute!(xs.as_ptr())
+        }
+
+        let s: &[u8] = $slice;
+
+            match <$wrapper>::from_bytes(unsafe { this_transmute(s) }) {
+                Ok(v) => v,
+                Err(_) => {
+                    return Err(Status::invalid_argument(format!(
+                        "unable to convert to type {}",
+                        $note
+                    )))
+                }
+            }
+
+    }};
+}
+
+#[cfg(feature = "std")]
 #[tonic::async_trait]
 impl Signer for MySign {
     /// BLS12-381 Signer service implementation
@@ -92,7 +117,7 @@ impl Signer for MySign {
         // construct the gRPC response from the key and return it
         Ok(Response::new(GenerateKeysResponse {
             secret_key: sk.to_bytes().to_vec(),
-            public_key: PublicKey::from(&sk).to_bytes().to_vec(),
+            public_key: PublicKey::from(&sk).to_raw_bytes().to_vec(),
         }))
     }
 
@@ -101,18 +126,7 @@ impl Signer for MySign {
         &self,
         request: Request<SignRequest>,
     ) -> Result<Response<SignResponse>, Status> {
-        // access the request parameters
-        let req = request.get_ref();
-        let sk = slice_as!(&req.secret_key, SecretKey, "SecretKey");
-        let pk = slice_as!(&req.public_key, PublicKey, "PublicKey");
-        // sign the message
-        let res =
-            ResponseSignature(sk.sign(&pk, &req.message).to_bytes().to_vec());
-
-        // return the signature wrapped in the response type
-        Ok(Response::new(SignResponse {
-            sig: Option::Some(res),
-        }))
+        self.sign_sync(&request)
     }
 
     /// Verify a BLS12-381 signature on a message with a given public key
@@ -120,19 +134,7 @@ impl Signer for MySign {
         &self,
         request: Request<VerifyRequest>,
     ) -> Result<Response<VerifyResponse>, Status> {
-        // access the request parameters
-        let req = request.get_ref();
-        let apk = slice_as!(&req.apk, APK, "APK");
-        let sig = slice_as!(&req.signature, Signature, "Signature");
-
-        // verify the message matches the signature and the signature matches the
-        // given public key
-        let res = apk.verify(&sig, &req.message);
-
-        // return whether the verification returned no error
-        Ok(Response::new(VerifyResponse {
-            ver: Some(Valid(!res.is_err())),
-        }))
+        self.verify_sync(&request)
     }
 
     /// Create an aggregated public key from a public key
@@ -142,10 +144,10 @@ impl Signer for MySign {
     ) -> Result<Response<CreateApkResponse>, Status> {
         // access the request parameters
         let req = request.get_ref();
-        let apk = slice_as!(&req.public_key, PublicKey, "PublicKey");
-        let apk = APK::from(&apk);
+        let pk = MySign::public_from_raw_unchecked(&req.public_key)?;
+        let apk = APK::from(&pk);
         Ok(Response::new(CreateApkResponse {
-            apk: Some(Apk(apk.to_bytes().to_vec())),
+            apk: Some(Apk(apk.to_raw_bytes().to_vec())),
         }))
     }
 
@@ -154,23 +156,7 @@ impl Signer for MySign {
         &self,
         request: Request<AggregatePkRequest>,
     ) -> Result<Response<AggregateResponse>, Status> {
-        // access the request parameters
-        let req = request.get_ref();
-        // get the apk first
-        let apk = slice_as!(&req.apk, PublicKey, "PublicKey");
-        let mut apk = APK::from_bytes(&apk.to_bytes()).unwrap();
-        // collect the list of public keys into a vector
-        let mut pks = Vec::with_capacity(req.keys.len());
-        for elem in &req.keys {
-            pks.push(slice_as!(&elem, PublicKey, "PublicKey"));
-        }
-        // aggregate the keys
-        apk.aggregate(&pks);
-        let bytes = apk.to_bytes();
-        // convert public key to aggregated public key and return it
-        Ok(Response::new(AggregateResponse {
-            agg: Some(Code(bytes.into())),
-        }))
+        self.aggregate_pk_sync(&request)
     }
 
     /// Aggregate a collection of signatures into an aggregated signature
@@ -186,7 +172,7 @@ impl Signer for MySign {
         let mut sigs: Vec<Signature> = Vec::with_capacity(req.signatures.len());
         // collect the list of public keys into a vector
         for elem in &req.signatures {
-            sigs.push(slice_as!(&elem, Signature, "Signature"));
+            sigs.push(slice_as!(elem, Signature, "Signature"));
         }
 
         // aggregate the signatures
@@ -197,6 +183,93 @@ impl Signer for MySign {
         // convert aggregate signature to bytes and return
         Ok(Response::new(AggregateResponse {
             agg: Some(Code(bytes)),
+        }))
+    }
+}
+
+impl MySign {
+    fn slice_to_fixed<const N: usize>(s: &[u8]) -> Result<[u8; N], Status> {
+        if s.len() != N {
+            Err(Status::invalid_argument(format!(
+                "invalid length {} - expected {}",
+                s.len(),
+                N
+            )))
+        } else {
+            let mut a: [u8; N] = [0u8; N];
+            a.copy_from_slice(s);
+            Ok(a)
+        }
+    }
+
+    fn signature_from_bytes(s: &[u8]) -> Result<Signature, Status> {
+        let sig_bytes = MySign::slice_to_fixed(s)?;
+        Signature::from_bytes(&sig_bytes)
+            .map_err(|_| Status::invalid_argument("Invalid signature bytes"))
+    }
+
+    fn public_from_raw_unchecked(s: &[u8]) -> Result<PublicKey, Status> {
+        let pk_bytes = MySign::slice_to_fixed(s)?;
+        PublicKey::from_raw_bytes(&pk_bytes)
+            .map_err(|_| Status::invalid_argument("Invalid public key"))
+    }
+
+    fn apk_from_raw_unchecked(s: &[u8]) -> Result<APK, Status> {
+        let pk_bytes = MySign::slice_to_fixed(s)?;
+        APK::from_raw_bytes(&pk_bytes).map_err(|_| {
+            Status::invalid_argument("Invalid aggregated public key")
+        })
+    }
+
+    fn sign_sync(
+        &self,
+        request: &Request<SignRequest>,
+    ) -> Result<Response<SignResponse>, Status> {
+        // access the request parameters
+        let req = request.get_ref();
+        let sk = slice_as!(req.secret_key.as_slice(), SecretKey, "SecretKey");
+        let pk = MySign::public_from_raw_unchecked(&req.public_key)?;
+        let res =
+            ResponseSignature(sk.sign(&pk, &req.message).to_bytes().to_vec());
+        // return the signature wrapped in the response type
+        Ok(Response::new(SignResponse { sig: Some(res) }))
+    }
+    /// Verify a BLS12-381 signature on a message with a given public key
+    fn verify_sync(
+        &self,
+        request: &Request<VerifyRequest>,
+    ) -> Result<Response<VerifyResponse>, Status> {
+        // access the request parameters
+        let req = request.get_ref();
+        let apk = MySign::apk_from_raw_unchecked(&req.apk)?;
+        let sig = MySign::signature_from_bytes(&req.signature)?;
+
+        // verify the message matches the signature and the signature matches the
+        // given public key
+        let res = apk.verify(&sig, &req.message);
+        // return whether the verification returned no error
+        Ok(Response::new(VerifyResponse {
+            ver: Some(Valid(res.is_ok())),
+        }))
+    }
+    fn aggregate_pk_sync(
+        &self,
+        request: &Request<AggregatePkRequest>,
+    ) -> Result<Response<AggregateResponse>, Status> {
+        // access the request parameters
+        let req = request.get_ref();
+        // get the apk first
+        let mut apk = MySign::apk_from_raw_unchecked(&req.apk)?;
+        // collect the list of public keys into a vector
+        let mut pks = Vec::with_capacity(req.keys.len());
+        for elem in &req.keys {
+            pks.push(MySign::public_from_raw_unchecked(elem)?);
+        }
+        // aggregate the keys
+        apk.aggregate(&pks);
+        // convert public key to aggregated public key and return it
+        Ok(Response::new(AggregateResponse {
+            agg: Some(Code(apk.to_raw_bytes().to_vec())),
         }))
     }
 }
@@ -248,4 +321,129 @@ fn main() {
 #[cfg(not(feature = "std"))]
 fn main() {
     panic!("std feature required");
+}
+
+extern crate test;
+
+#[cfg(test)]
+mod benches_svc {
+    use dusk_bls12_381_sign::{PublicKey, SecretKey};
+    use rand::RngCore;
+    use test::Bencher;
+
+    use crate::*;
+
+    #[bench]
+    fn bench_sign(b: &mut Bencher) {
+        let signer = MySign {};
+        let sk = SecretKey::new(&mut rand::thread_rng());
+        let req = Request::new(SignRequest {
+            message: random_message().to_vec(),
+            public_key: PublicKey::from(&sk).to_raw_bytes().to_vec(),
+            secret_key: sk.to_bytes().to_vec(),
+        });
+        b.iter(|| signer.sign_sync(&req));
+    }
+
+    #[bench]
+    fn bench_verify(b: &mut Bencher) {
+        let sk = SecretKey::new(&mut rand::thread_rng());
+        let pk = PublicKey::from(&sk);
+        let msg = random_message().to_vec();
+        let signer = MySign {};
+        let req = Request::new(SignRequest {
+            message: msg.to_vec(),
+            public_key: pk.to_raw_bytes().to_vec(),
+            secret_key: sk.to_bytes().to_vec(),
+        });
+        let signres = signer.sign_sync(&req).unwrap();
+        let sig = signres.get_ref().sig.as_ref().unwrap();
+        if let ResponseSignature(a) = sig {
+            let ver = Request::new(VerifyRequest {
+                apk: APK::from(&pk).to_raw_bytes().to_vec(),
+                signature: a.to_vec(),
+                message: msg.to_vec(),
+            });
+            b.iter(|| {
+                let signer = MySign {};
+                let mut res = signer.verify_sync(&ver).unwrap();
+                let a = res.get_mut().ver.take();
+                match a.unwrap() {
+                    Valid(e) => {
+                        assert!(e);
+                    }
+                    _ => {
+                        assert!(false);
+                    }
+                }
+            });
+        } else {
+            panic!("help")
+        }
+    }
+
+    fn random_message() -> [u8; 100] {
+        let mut msg = [0u8; 100];
+        (&mut rand::thread_rng()).fill_bytes(&mut msg);
+        msg
+    }
+}
+
+#[cfg(test)]
+mod tests_svc {
+    use crate::*;
+    use crate::{PublicKey, SecretKey, APK};
+    use rand::RngCore;
+
+    #[test]
+    fn sign_verify() {
+        let signer = MySign {};
+        let sk = SecretKey::new(&mut rand::thread_rng());
+        let pk = PublicKey::from(&sk);
+        let msg = random_message().to_vec();
+        let req = Request::new(SignRequest {
+            message: msg.to_vec(),
+            public_key: pk.to_raw_bytes().to_vec(),
+            secret_key: sk.to_bytes().to_vec(),
+        });
+        let signres = signer.sign_sync(&req).unwrap();
+        let sig = signres.get_ref().sig.as_ref().unwrap();
+
+        if let ResponseSignature(a) = sig {
+            let ver = Request::new(VerifyRequest {
+                apk: APK::from(&pk).to_raw_bytes().to_vec(),
+                signature: a.to_vec(),
+                message: msg.to_vec(),
+            });
+
+            let sig = MySign::slice_to_fixed(&a).unwrap();
+            let sig = Signature::from_bytes(&sig).unwrap();
+            // Verification with the standard pk should fail.
+            assert!(pk.verify(&sig, &msg).is_err());
+
+            // Verification with the aggregated version should work.
+            let apk = APK::from(&pk);
+            assert!(apk.verify(&sig, &msg).is_ok());
+
+            let signer = MySign {};
+            let mut res = signer.verify_sync(&ver).unwrap();
+            let a = res.get_mut().ver.take();
+            match a.unwrap() {
+                Valid(e) => {
+                    assert!(e);
+                }
+                _ => {
+                    assert!(false);
+                }
+            }
+        } else {
+            panic!("help")
+        }
+    }
+
+    fn random_message() -> [u8; 100] {
+        let mut msg = [0u8; 100];
+        (&mut rand::thread_rng()).fill_bytes(&mut msg);
+        msg
+    }
 }


### PR DESCRIPTION
Avoid checks performed by PublicKey::from_bytes and APK::from_bytes to speed up gRPC service

Resolves: #23