### PR TITLE
Update deps

### DIFF
--- a/rust/bls12_381-sign-ffi/Cargo.toml
+++ b/rust/bls12_381-sign-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-bls12_381-sign-ffi"
-version = "0.1.0-rc.0"
+version = "0.2.0-rc.0"
 authors = [
     "Jules de Smit <julesdesmit@gmail.com>",
     "Matteo Ferretti <matteo@dusk.network>",
@@ -12,7 +12,7 @@ description = "Implementation of BLS signatures using the BLS12-381 curve"
 license = "MPL-2.0"
 
 [dependencies]
-dusk-bls12_381 = { version = "0.8", default-features = false }
+dusk-bls12_381 = { version = "0.9", default-features = false }
 dusk-bls12_381-sign = { path = "../bls12_381-sign" }
 dusk-bytes = "0.1"
 libc = "0.2"

--- a/rust/bls12_381-sign/Cargo.toml
+++ b/rust/bls12_381-sign/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-bls12_381-sign"
-version = "0.2.0-rc.0"
+version = "0.3.0-rc.0"
 authors = [
     "Jules de Smit <julesdesmit@gmail.com>",
     "Matteo Ferretti <matteo@dusk.network>",
@@ -13,9 +13,9 @@ license = "MPL-2.0"
 
 [dependencies]
 blake2 = { version = "0.10", default-features = false }
-canonical = { version = "0.6", optional = true }
-canonical_derive = { version = "0.6", optional = true }
-dusk-bls12_381 = { version = "0.8", default-features = false, features = ["pairings"] }
+canonical = { version = "0.7", optional = true }
+canonical_derive = { version = "0.7", optional = true }
+dusk-bls12_381 = { version = "0.9", default-features = false, features = ["pairings"] }
 dusk-bytes = "0.1"
 rand_core = { version = "0.6", default-features = false }
 

--- a/rust/grpc-server/Cargo.toml
+++ b/rust/grpc-server/Cargo.toml
@@ -1,12 +1,12 @@
 #![feature(min_const_generics)]
 [package]
 name = "dusk-bls12_381-sign-ipc"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Loki <david@dusk.network>"]
 edition = "2018"
 
 [dependencies]
-dusk-bls12_381-sign = { version = "0.2.0-rc", path = "../bls12_381-sign" }
+dusk-bls12_381-sign = { version = "0.3.0-rc", path = "../bls12_381-sign" }
 async-stream = "0.3"
 dusk-bytes = "0.1"
 futures = { version = "0.3", default-features = false, features = ["alloc"] }


### PR DESCRIPTION
- grpc-server: Bump to `0.2.0`

  - Update `dusk-bls12_381-sign` from `0.2.0-rc` to `0.3.0-rc`

- bls12_381-sign-ffi: Bump to `0.2.0-rc.0`

  - Update `dusk-bls12_381` from `0.8` to `0.9`

- bls12_381-sign: Bump to `0.3.0-rc.0`

  - Update `canonical` from `0.6` to `0.7`
  - Update `canonical_derive` from `0.6` to `0.7`
  - Update `dusk-bls12_381` from `0.8` to `0.9`
