### PR TITLE
Add `parallel` feature

### DIFF
--- a/rust/bls12_381-sign/Cargo.toml
+++ b/rust/bls12_381-sign/Cargo.toml
@@ -19,6 +19,7 @@ rand_core = { version = "0.6", default-features = false }
 rkyv = { version = "0.7", optional = true, default-features = false }
 bytecheck = { version = "0.6", optional = true, default-features = false }
 ff = { version = "0.13", default-features = false }
+rayon = { version = "1.8", optional = true }
 
 [dev-dependencies]
 rand = { version = "0.8", default-features = false, features = ["std_rng"] }
@@ -29,3 +30,4 @@ rkyv-impl = [
     "rkyv",
     "bytecheck",
 ]
+parallel = ["dep:rayon"]

--- a/rust/bls12_381-sign/benches/signature_bench.rs
+++ b/rust/bls12_381-sign/benches/signature_bench.rs
@@ -54,6 +54,36 @@ mod benches {
         b.iter(|| apk.aggregate(&[pk]));
     }
 
+    #[bench]
+    fn bench_aggregate_pk_64_bulk(b: &mut Bencher) {
+        let sk = SecretKey::random(&mut OsRng);
+        let pk = PublicKey::from(&sk);
+        let mut apk = APK::from(&pk);
+        let mut pks = vec![];
+        for _ in 0..64 {
+            let sk = SecretKey::random(&mut OsRng);
+            let pk = PublicKey::from(&sk);
+            pks.push(pk)
+        }
+        let pks = &pks[..];
+        b.iter(|| apk.aggregate(pks));
+    }
+
+    #[bench]
+    fn bench_aggregate_pk_64_each(b: &mut Bencher) {
+        let sk = SecretKey::random(&mut OsRng);
+        let pk = PublicKey::from(&sk);
+        let mut apk = APK::from(&pk);
+        let mut pks = vec![];
+        for _ in 0..64 {
+            let sk = SecretKey::random(&mut OsRng);
+            let pk = PublicKey::from(&sk);
+            pks.push(pk)
+        }
+        let pks = &pks[..];
+        b.iter(|| pks.iter().for_each(|&p| apk.aggregate(&[p])));
+    }
+
     fn random_message() -> [u8; 100] {
         let mut msg = [0u8; 100];
         (&mut OsRng::default()).fill_bytes(&mut msg);

--- a/rust/bls12_381-sign/tests/signature.rs
+++ b/rust/bls12_381-sign/tests/signature.rs
@@ -115,13 +115,15 @@ fn sign_verify_aggregated() {
 
     let mut apk = APK::from(&pk);
 
+    let mut pks = vec![];
     for _ in 0..10 {
         let sk = SecretKey::random(rng);
         let pk = PublicKey::from(&sk);
         let sig = sk.sign(&pk, &msg);
         agg_sig = agg_sig.aggregate(&[sig]);
-        apk.aggregate(&[pk]);
+        pks.push(pk)
     }
+    apk.aggregate(&pks[..]);
 
     assert!(apk.verify(&agg_sig, &msg).is_ok());
 }


### PR DESCRIPTION
Below the bench results

**No feature**
```
test benches::bench_aggregate_pk              ... bench:     885,060 ns/iter (+/- 26,413)
test benches::bench_aggregate_pk_64_bulk      ... bench:  54,868,104 ns/iter (+/- 2,903,134)
test benches::bench_aggregate_pk_64_each      ... bench:  56,550,741 ns/iter (+/- 1,433,879)
```

**`parallel` feature**
```
test benches::bench_aggregate_pk              ... bench:     889,333 ns/iter (+/- 31,869)
test benches::bench_aggregate_pk_64_bulk      ... bench:   7,850,960 ns/iter (+/- 2,077,702)
test benches::bench_aggregate_pk_64_each      ... bench:  56,553,808 ns/iter (+/- 941,238)
```


See also https://github.com/dusk-network/rusk/issues/1149