### PR TITLE
Deprecate crate

### DIFF
--- a/rust/bls12_381-sign/Cargo.toml
+++ b/rust/bls12_381-sign/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 description = "Implementation of BLS signatures using the BLS12-381 curve"
 license = "MPL-2.0"
 
+[badges]
+maintanance = { status = "depracated" }
+
 [dependencies]
 blake2 = { version = "0.10", default-features = false }
 dusk-bls12_381 = { version = "0.13", default-features = false, features = ["alloc", "pairings"] }

--- a/rust/bls12_381-sign/README.md
+++ b/rust/bls12_381-sign/README.md
@@ -1,3 +1,8 @@
+# Disclaimer
+**This crate is not in active development anymore, use [bls12_381-bls](https://github.com/dusk-network/bls12_381-bls) instead.**
+
+---
+
 # Implementation of [BLS signatures](https://crypto.stanford.edu/~dabo/pubs/papers/BLSmultisig.html) using the BLS12-381 curve.
 
 This implementation currently only supports rogue-key attack resistant batching, and does not support distinct message verification.


### PR DESCRIPTION
This crate is not in active development anymore, use [bls12_381-bls](https://github.com/dusk-network/bls12_381-bls) instead.

Resolves #66 #67 #30